### PR TITLE
Remove substitutions for persistent disks from ops file

### DIFF
--- a/pcf-cloud-config-ops.yml
+++ b/pcf-cloud-config-ops.yml
@@ -1,20 +1,4 @@
 - type: replace
-  path: /instance_groups/name=alertmanager/persistent_disk_type
-  value: 1024
-
-- type: replace
-  path: /instance_groups/name=prometheus/persistent_disk_type
-  value: 10240
-
-- type: replace
-  path: /instance_groups/name=database/persistent_disk_type
-  value: 10240
-
-- type: replace
-  path: /instance_groups/name=grafana/persistent_disk_type
-  value: 1024
-
-- type: replace
   path: /instance_groups/name=alertmanager/vm_type
   value: ((vm_type_micro))
 


### PR DESCRIPTION
This was fixed in the bosh release here: https://github.com/bosh-prometheus/prometheus-boshrelease/commit/7250165dd8a494b99dbde85aa2f653ad8ee1d17d#diff-b89e7864c5c954d3a31928c559086d76