### PR TITLE
Update to prometheus-boshrelease v23

### DIFF
--- a/pcf-cloud-config-ops-migration.yml
+++ b/pcf-cloud-config-ops-migration.yml
@@ -1,0 +1,11 @@
+- type: replace
+  path: /instance_groups/name=prometheus?/vm_type
+  value: ((vm_type_small))
+
+- type: replace
+  path: /instance_groups/name=prometheus?/networks
+  value: ((network))
+
+- type: replace
+  path: /instance_groups/name=prometheus?/azs
+  value: ((azs))

--- a/pcf-cloud-config-ops.yml
+++ b/pcf-cloud-config-ops.yml
@@ -3,7 +3,7 @@
   value: ((vm_type_micro))
 
 - type: replace
-  path: /instance_groups/name=prometheus/vm_type
+  path: /instance_groups/name=prometheus2/vm_type
   value: ((vm_type_small))
 
 - type: replace
@@ -27,7 +27,7 @@
   value: ((network))
 
 - type: replace
-  path: /instance_groups/name=prometheus/networks
+  path: /instance_groups/name=prometheus2/networks
   value: ((network))
 
 - type: replace
@@ -51,7 +51,7 @@
   value: ((azs))
 
 - type: replace
-  path: /instance_groups/name=prometheus/azs
+  path: /instance_groups/name=prometheus2/azs
   value: ((azs))
 
 - type: replace

--- a/pcf-cloud-config-ops.yml
+++ b/pcf-cloud-config-ops.yml
@@ -3,6 +3,10 @@
   value: ((vm_type_micro))
 
 - type: replace
+  path: /instance_groups/name=prometheus?/vm_type
+  value: ((vm_type_small))
+
+- type: replace
   path: /instance_groups/name=prometheus2/vm_type
   value: ((vm_type_small))
 
@@ -27,6 +31,10 @@
   value: ((network))
 
 - type: replace
+  path: /instance_groups/name=prometheus?/networks
+  value: ((network))
+
+- type: replace
   path: /instance_groups/name=prometheus2/networks
   value: ((network))
 
@@ -48,6 +56,10 @@
 
 - type: replace
   path: /instance_groups/name=alertmanager/azs
+  value: ((azs))
+
+- type: replace
+  path: /instance_groups/name=prometheus?/azs
   value: ((azs))
 
 - type: replace

--- a/pcf-cloud-config-ops.yml
+++ b/pcf-cloud-config-ops.yml
@@ -3,10 +3,6 @@
   value: ((vm_type_micro))
 
 - type: replace
-  path: /instance_groups/name=prometheus?/vm_type
-  value: ((vm_type_small))
-
-- type: replace
   path: /instance_groups/name=prometheus2/vm_type
   value: ((vm_type_small))
 
@@ -31,10 +27,6 @@
   value: ((network))
 
 - type: replace
-  path: /instance_groups/name=prometheus?/networks
-  value: ((network))
-
-- type: replace
   path: /instance_groups/name=prometheus2/networks
   value: ((network))
 
@@ -56,10 +48,6 @@
 
 - type: replace
   path: /instance_groups/name=alertmanager/azs
-  value: ((azs))
-
-- type: replace
-  path: /instance_groups/name=prometheus?/azs
   value: ((azs))
 
 - type: replace

--- a/pcf-colocate-firehose_exporter.yml
+++ b/pcf-colocate-firehose_exporter.yml
@@ -8,7 +8,7 @@
 
 # run firehose_exporter job on the prometheus instance_group
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/-
+  path: /instance_groups/name=prometheus2/jobs/-
   value:
     name: firehose_exporter
     release: prometheus
@@ -28,7 +28,7 @@
 
 # add local firehose_exporter as a target
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
     job_name: firehose_exporter
     static_configs:

--- a/pcf-local-cf_exporter.yml
+++ b/pcf-local-cf_exporter.yml
@@ -3,7 +3,7 @@
 # running on the Prometheus instance group so we can hardcode the localhost address
 
 - type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
   value:
       job_name: cf_exporter
       static_configs:

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -3,7 +3,7 @@ resource_types:
   type: docker-image
   source:
     repository: mkuratczyk/bosh-creds-resource
-    tag: 1.3
+    tag: 1.4
 - name: bosh-deploy
   type: docker-image
   source:
@@ -44,8 +44,6 @@ resources:
     external_bosh_ca_cert: ((external_bosh_ca_cert))
 - name: bosh-deployment
   type: bosh-deploy
-  source:
-    deployment: prometheus
 
 jobs:
 - name: create-uaa-clients
@@ -78,9 +76,8 @@ jobs:
   - get: prometheus-release-git
   - get: prometheus-release-blob
   - get: pcf-bosh-creds
-  - get: bosh-deployment
     params:
-      source_file: pcf-bosh-creds/((director_for_deployment)).json
+      deployment: ((deployment_name))
   - task: retrieve-params-from-opsman
     file: pcf-prometheus-pipeline/pipeline/tasks/retrieve-params-from-opsman.yml
     params:
@@ -89,9 +86,12 @@ jobs:
       opsman_url: ((opsman_url))
   - task: check-if-migration-required
     file: pcf-prometheus-pipeline/pipeline/tasks/check-if-migration-required.yml
+    params:
+      deployment_name: ((deployment_name))
   - put: bosh-deployment
     params:
       source_file: pcf-bosh-creds/((director_for_deployment)).json
+      deployment: ((deployment_name))
       manifest: prometheus-release-git/manifests/prometheus.yml
       releases:
       - prometheus-release-blob/prometheus-*.tgz

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -66,7 +66,7 @@ jobs:
   - aggregate:
     - get: node-exporter-release
     - get: pcf-prometheus-pipeline
-      cipassed: [create-uaa-clients]
+      passed: [create-uaa-clients]
     - get: pcf-bosh-creds
   - task: install-node-exporter
     file: pcf-prometheus-pipeline/pipeline/tasks/install-node-exporter.yml

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -14,13 +14,12 @@ resources:
   type: git
   source:
     uri: https://github.com/pivotal-cf/pcf-prometheus-pipeline.git
-    branch: master
+    branch: prometheus-v22
 - name: prometheus-release-git
   type: git
   source:
     uri: https://github.com/bosh-prometheus/prometheus-boshrelease.git
     branch: master
-    tag_filter: v21.*
 - name: prometheus-release-blob
   type: github-release
   source:
@@ -76,7 +75,6 @@ jobs:
     passed: [install-node-exporter]
   - get: prometheus-release-git
   - get: prometheus-release-blob
-    version: { tag: 'v21.1.1' }
   - get: pcf-bosh-creds
     params:
       deployment: prometheus

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -44,6 +44,8 @@ resources:
     external_bosh_ca_cert: ((external_bosh_ca_cert))
 - name: bosh-deployment
   type: bosh-deploy
+  source:
+    deployment: prometheus
 
 jobs:
 - name: create-uaa-clients
@@ -64,7 +66,7 @@ jobs:
   - aggregate:
     - get: node-exporter-release
     - get: pcf-prometheus-pipeline
-      passed: [create-uaa-clients]
+      cipassed: [create-uaa-clients]
     - get: pcf-bosh-creds
   - task: install-node-exporter
     file: pcf-prometheus-pipeline/pipeline/tasks/install-node-exporter.yml
@@ -76,22 +78,25 @@ jobs:
   - get: prometheus-release-git
   - get: prometheus-release-blob
   - get: pcf-bosh-creds
+  - get: bosh-deployment
     params:
-      deployment: prometheus
+      source_file: pcf-bosh-creds/((director_for_deployment)).json
   - task: retrieve-params-from-opsman
     file: pcf-prometheus-pipeline/pipeline/tasks/retrieve-params-from-opsman.yml
     params:
       pcf_opsman_admin_username: ((pcf_opsman_admin_username))
       pcf_opsman_admin_password: ((pcf_opsman_admin_password))
       opsman_url: ((opsman_url))
+  - task: check-if-migration-required
+    file: pcf-prometheus-pipeline/pipeline/tasks/check-if-migration-required.yml
   - put: bosh-deployment
     params:
       source_file: pcf-bosh-creds/((director_for_deployment)).json
-      deployment: prometheus
       manifest: prometheus-release-git/manifests/prometheus.yml
       releases:
       - prometheus-release-blob/prometheus-*.tgz
       ops_files:
+      - migration/*.yml
       - prometheus-release-git/manifests/operators/monitor-bosh.yml
       - prometheus-release-git/manifests/operators/enable-bosh-uaa.yml
       - prometheus-release-git/manifests/operators/monitor-cf.yml

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -14,7 +14,7 @@ resources:
   type: git
   source:
     uri: https://github.com/pivotal-cf/pcf-prometheus-pipeline.git
-    branch: prometheus-v22
+    branch: master
 - name: prometheus-release-git
   type: git
   source:

--- a/pipeline/tasks/check-if-migration-required.sh
+++ b/pipeline/tasks/check-if-migration-required.sh
@@ -26,4 +26,4 @@ if [ $? != 0 ]; then
 fi
 
 # Prometheus v1 job exists; add migration ops file
-cp prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml "${OPS_DIR}"
+cp prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml migration/

--- a/pipeline/tasks/check-if-migration-required.sh
+++ b/pipeline/tasks/check-if-migration-required.sh
@@ -29,5 +29,6 @@ fi
 
 set -e
 
-# Prometheus v1 job exists; add migration ops file
+# Prometheus v1 job exists; add migration ops files
 cp prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml migration/
+cp pcf-prometheus-pipeline/pcf-cloud-config-ops-migration.yml migration/

--- a/pipeline/tasks/check-if-migration-required.sh
+++ b/pipeline/tasks/check-if-migration-required.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# required for `migration/*.yml` to find something
+touch migration/empty.yml
+
+# check if `prometheus` instance group exists
+if grep -q '  name: prometheus$' < bosh-deployment/manifest.yml; then
+  # add migration ops file if yes
+  cat prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml > "${OPS_DIR}/migrate_from_prometheus_1.yml"
+fi

--- a/pipeline/tasks/check-if-migration-required.sh
+++ b/pipeline/tasks/check-if-migration-required.sh
@@ -10,6 +10,8 @@ touch migration/empty.yml
 
 login_to_director pcf-bosh-creds
 
+set +e
+
 # check if a previous deployment exists
 bosh2 -n deployments | grep -q "^${deployment_name} "
 
@@ -24,6 +26,8 @@ bosh2 -n -d ${deployment_name} vms | grep -q 'prometheus/'
 if [ $? != 0 ]; then
   exit 0
 fi
+
+set -e
 
 # Prometheus v1 job exists; add migration ops file
 cp prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml migration/

--- a/pipeline/tasks/check-if-migration-required.yml
+++ b/pipeline/tasks/check-if-migration-required.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: starkandwayne/concourse
+
+inputs:
+- name: bosh-deployment
+
+outputs:
+- name: migration
+
+run:
+  path: pcf-prometheus-pipeline/pipeline/tasks/check-if-migration-required.sh

--- a/pipeline/tasks/check-if-migration-required.yml
+++ b/pipeline/tasks/check-if-migration-required.yml
@@ -8,7 +8,7 @@ image_resource:
 
 inputs:
 - name: pcf-prometheus-pipeline
-- name: bosh-deployment
+- name: pcf-bosh-creds
 
 outputs:
 - name: migration

--- a/pipeline/tasks/check-if-migration-required.yml
+++ b/pipeline/tasks/check-if-migration-required.yml
@@ -7,6 +7,7 @@ image_resource:
     repository: starkandwayne/concourse
 
 inputs:
+- name: pcf-prometheus-pipeline
 - name: bosh-deployment
 
 outputs:

--- a/pipeline/tasks/check-if-migration-required.yml
+++ b/pipeline/tasks/check-if-migration-required.yml
@@ -9,6 +9,7 @@ image_resource:
 inputs:
 - name: pcf-prometheus-pipeline
 - name: pcf-bosh-creds
+- name: prometheus-release-git
 
 outputs:
 - name: migration

--- a/pipeline/tasks/install-node-exporter.sh
+++ b/pipeline/tasks/install-node-exporter.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-TMPDIR=${TMPDIR:-/tmp}
-TMPFILE=$(mktemp "$TMPDIR/runtime-config.XXXXXX")
-
 root_dir=$(cd "$(dirname "$0")/.." && pwd)
 
 source ${root_dir}/tasks/common.sh

--- a/pipeline/tasks/retrieve-params-from-opsman.sh
+++ b/pipeline/tasks/retrieve-params-from-opsman.sh
@@ -38,3 +38,5 @@ if [[ "${mysql_address}" != "null" ]]; then
   echo "mysql_password: ${mysql_password}" >> ${PARAMS_FILE}
   ln -s prometheus-release-git/manifests/operators/monitor-mysql.yml ${OPS_DIR}/monitor-mysql.yml
 fi
+
+ln -s prometheus-release-git/manifests/operators/migrate_from_prometheus_1.yml ${OPS_DIR}/migrate_from_prometheus_1.yml

--- a/pipeline/tasks/retrieve-params-from-opsman.sh
+++ b/pipeline/tasks/retrieve-params-from-opsman.sh
@@ -36,7 +36,6 @@ if [[ "${mysql_address}" != "null" ]]; then
   echo "mysql_address: ${mysql_address}" >> ${PARAMS_FILE}
   echo "mysql_username: ${mysql_username}" >> ${PARAMS_FILE}
   echo "mysql_password: ${mysql_password}" >> ${PARAMS_FILE}
-  ln -s prometheus-release-git/manifests/operators/monitor-mysql.yml ${OPS_DIR}/monitor-mysql.yml
 fi
 
 cat prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml > ${OPS_DIR}/migrate_from_prometheus_1.yml

--- a/pipeline/tasks/retrieve-params-from-opsman.sh
+++ b/pipeline/tasks/retrieve-params-from-opsman.sh
@@ -36,6 +36,5 @@ if [[ "${mysql_address}" != "null" ]]; then
   echo "mysql_address: ${mysql_address}" >> ${PARAMS_FILE}
   echo "mysql_username: ${mysql_username}" >> ${PARAMS_FILE}
   echo "mysql_password: ${mysql_password}" >> ${PARAMS_FILE}
+  ln -s prometheus-release-git/manifests/operators/monitor-mysql.yml ${OPS_DIR}/monitor-mysql.yml
 fi
-
-cat prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml > ${OPS_DIR}/migrate_from_prometheus_1.yml

--- a/pipeline/tasks/retrieve-params-from-opsman.sh
+++ b/pipeline/tasks/retrieve-params-from-opsman.sh
@@ -39,4 +39,4 @@ if [[ "${mysql_address}" != "null" ]]; then
   ln -s prometheus-release-git/manifests/operators/monitor-mysql.yml ${OPS_DIR}/monitor-mysql.yml
 fi
 
-cat prometheus-release-git/manifests/operators/migrate_from_prometheus_1.yml > ${OPS_DIR}/migrate_from_prometheus_1.yml
+cat prometheus-release-git/manifests/operators/migrations/migrate_from_prometheus_1.yml > ${OPS_DIR}/migrate_from_prometheus_1.yml

--- a/pipeline/tasks/retrieve-params-from-opsman.sh
+++ b/pipeline/tasks/retrieve-params-from-opsman.sh
@@ -39,4 +39,4 @@ if [[ "${mysql_address}" != "null" ]]; then
   ln -s prometheus-release-git/manifests/operators/monitor-mysql.yml ${OPS_DIR}/monitor-mysql.yml
 fi
 
-ln -s prometheus-release-git/manifests/operators/migrate_from_prometheus_1.yml ${OPS_DIR}/migrate_from_prometheus_1.yml
+cat prometheus-release-git/manifests/operators/migrate_from_prometheus_1.yml > ${OPS_DIR}/migrate_from_prometheus_1.yml

--- a/pipeline/tasks/retrieve-params-from-opsman.yml
+++ b/pipeline/tasks/retrieve-params-from-opsman.yml
@@ -8,6 +8,7 @@ image_resource:
 
 inputs:
 - name: pcf-prometheus-pipeline
+- name: prometheus-release-git
 
 outputs:
 - name: dynamic-params


### PR DESCRIPTION
Use the latest prometheus-boshrelease. Automatically apply migration from v1 if a deployment with `prometheus` job exists.